### PR TITLE
docs: Modify deprecated APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ export default defineConfig({
       entry: path.resolve('src/main.ts'), // or you can use entry: [path.resolve('src/main.ts')]
       enabled: true,
       config: {
-        maxLogNumber: 1000,
+        log: {
+          maxLogNumber: 1000,
+        },
         theme: 'dark'
       }
     })
@@ -97,7 +99,9 @@ export default defineConfig({
       entry: [path.resolve('src/main.ts')], // entry for each page, different from the above
       enabled: true,
       config: {
-        maxLogNumber: 1000,
+        log: {
+          maxLogNumber: 1000,
+        },
         theme: 'dark'
       }
     })
@@ -121,7 +125,9 @@ export default defineConfig({
       entry: path.resolve('src/main.tsx'),
       enabled: true,
       config: {
-        maxLogNumber: 1000,
+        log: {
+          maxLogNumber: 1000,
+        },
         theme: 'dark'
       }
     })
@@ -147,7 +153,9 @@ export default ({ command, mode }: ConfigEnv): UserConfigExport => {
         entry: [path.resolve('src/main.ts')], // entry file
         enabled: command !== 'serve' || mode === 'test', // build production
         config: { // vconsole options
-          maxLogNumber: 1000，
+          log: {
+            maxLogNumber: 1000,
+          },
           theme: 'light'
         }
       })

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -75,7 +75,9 @@ export default defineConfig({
       entry: path.resolve('src/main.ts'), // 或者可以使用这个配置: [path.resolve('src/main.ts')]
       enabled: true, // 可自行结合 mode 和 command 进行判断
       config: {
-        maxLogNumber: 1000,
+        log: {
+          maxLogNumber: 1000,
+        },
         theme: 'dark'
       }
     })
@@ -99,7 +101,9 @@ export default defineConfig({
       entry: [path.resolve('src/main.ts')], // 每个页面的入口文件，和上面不一样的地方，这里是一个数组
       enabled: true, // 可自行结合 mode 和 command 进行判断
       config: {
-        maxLogNumber: 1000,
+        log: {
+          maxLogNumber: 1000,
+        },
         theme: 'dark'
       }
     })
@@ -123,7 +127,9 @@ export default defineConfig({
       entry: path.resolve('src/main.tsx'),
       enabled: true, // 可自行结合 mode 和 command 进行判断
       config: {
-        maxLogNumber: 1000,
+        log: {
+          maxLogNumber: 1000,
+        },
         theme: 'dark'
       }
     })
@@ -148,7 +154,9 @@ export default ({ command, mode }: ConfigEnv): UserConfigExport => {
         entry: [path.resolve('src/main.ts')], // 入口文件
         enabled: command !== 'serve' || mode === 'test', // 打包环境下/发布测试包
         config: { // vconsole 配置项
-          maxLogNumber: 1000，
+          log: {
+            maxLogNumber: 1000,
+          },
           theme: 'light'
         }
       })


### PR DESCRIPTION
maxLogNumber has been deprecated Since v3.12.0
May be we should use `log.maxLogNumber` ?
![3c6f03d6092a96151c6d9adbec13ecca](https://github.com/user-attachments/assets/362820c9-2af0-4bd2-8f5a-baf7421d3d10)
![3ee334cfb5892f877cbb6ae4b75a14f1](https://github.com/user-attachments/assets/6ae3b208-1c14-480e-a9ff-621947bb7788)
